### PR TITLE
indexing of bim and fam files removed

### DIFF
--- a/pandas_plink/_read.py
+++ b/pandas_plink/_read.py
@@ -44,15 +44,18 @@ def read_plink(file_prefix, verbose=True):
             >>> from pandas_plink import example_file_prefix
             >>> (bim, fam, bed) = read_plink(example_file_prefix(), verbose=False)
             >>> print(bim.head()) #doctest: +NORMALIZE_WHITESPACE
-                                snp   cm a0 a1  i
-            chrom pos
-            1     45162  rs10399749  0.0  G  C  0
-                  45257   rs2949420  0.0  C  T  1
-                  45413   rs2949421  0.0  0  0  2
-                  46844   rs2691310  0.0  A  T  3
-                  72434   rs4030303  0.0  0  G  4
+              chrom         snp   cm     pos a0 a1  i
+            0     1  rs10399749  0.0   45162  G  C  0
+            1     1   rs2949420  0.0   45257  C  T  1
+            2     1   rs2949421  0.0   45413  0  0  2
+            3     1   rs2691310  0.0   46844  A  T  3
+            4     1   rs4030303  0.0   72434  0  G  4
+            5     1   rs4030300  0.0   72515  0  C  5
+            6     1   rs3855952  0.0   77689  G  A  6
+            7     1    rs940550  0.0   78032  0  T  7
+            8     1  rs13328714  0.0   81468  G  C  8
+            9     1  rs11490937  0.0  222077  A  G  9
             >>> print(fam.head()) #doctest: +NORMALIZE_WHITESPACE
-                                 father    mother gender trait  i
             fid      iid
             Sample_1 Sample_1         0         0      1    -9  0
             Sample_2 Sample_2         0         0      2    -9  1
@@ -77,7 +80,7 @@ def read_plink(file_prefix, verbose=True):
             >>> from pandas_plink import read_plink
             >>> from pandas_plink import example_file_prefix
             >>> (bim, fam, bed) = read_plink(example_file_prefix(), verbose=False)
-            >>> chrom1 = bim.loc[('1', ), :]
+            >>> chrom1 = bim.query("chrom=='1'") 
             >>> X = bed[chrom1.i,:].compute()
             >>> print(X) #doctest: +NORMALIZE_WHITESPACE
             [[2 2 1]
@@ -123,8 +126,6 @@ def _read_bim(fn):
     df['a0'] = df['a0'].astype('category')
     df['a1'] = df['a1'].astype('category')
     df['i'] = range(df.shape[0])
-    df.set_index(['chrom', 'pos'], inplace=True)
-    df.sort_index(inplace=True)
     return df
 
 
@@ -139,12 +140,10 @@ def _read_fam(fn):
         names=header.keys(),
         dtype=header,
         compression=None,
-        index_col=['fid', 'iid'],
         engine='c')
 
     df['gender'] = df['gender'].astype('category')
     df['i'] = range(df.shape[0])
-    df.sort_index(inplace=True)
     return df
 
 def _read_bed(fn, nsamples, nmarkers):

--- a/pandas_plink/test/test_reader.py
+++ b/pandas_plink/test/test_reader.py
@@ -13,16 +13,18 @@ def _ascii_airlock(v):
     return v
 
 def test_read_plink():
+
     datafiles = join(dirname(realpath(__file__)), 'data_files')
     file_prefix = join(datafiles, 'data')
 
     (bim, fam, bed) = read_plink(file_prefix)
 
-    assert_array_equal(bim.loc[('1', 72515), 'snp'], ['rs4030300'])
-    assert_array_equal(bim.loc[('1', ), :].shape, [10, 5])
-    assert_array_equal(fam.loc[('Sample_2', 'Sample_2'), 'trait'], ['-9'])
+    assert_array_equal(bim.query("chrom=='1' and pos==72515")['snp'], ['rs4030300'])
+    assert_array_equal(bim.query("chrom=='1'").shape, [10, 7])
+    assert_array_equal(fam.query("fid=='Sample_2' and iid=='Sample_2'")["trait"], ['-9'])
 
     assert_array_equal(bed,
                        array([[2, 2, 1], [2, 1, 2], [3, 3, 3], [3, 3, 1],
                               [2, 2, 2], [2, 2, 2], [2, 1, 0], [2, 2, 2],
                               [1, 2, 2], [2, 1, 2]]))
+


### PR DESCRIPTION
Removed indexing of bim and fam files. Queries on the variants and individuals are now made using pandas queries on the bim and fam dataframe.